### PR TITLE
remove 'stream-legacy' from oldTags.

### DIFF
--- a/rfcs.js
+++ b/rfcs.js
@@ -7,7 +7,6 @@ const tagTypes = ['collection', 'status', 'stream', 'level', 'wg']
 const unshownTagTypes = ['status']
 const oldTags = [
   'status-obsoleted',
-  'stream-legacy',
   'level-historic'
 ]
 


### PR DESCRIPTION
The meaning of "stream: legacy" is "The RFC was published before a
formal source (e.g., working group or stream) existed or was recorded."
(https://www.rfc-editor.org/source-definitions/).  For example,
the stream of RFC1035 is "legacy" but it is not obsoleted.