### PR TITLE
use "make lint" to run "standard" command.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,5 +29,5 @@ try to keep the size of that (and other) files down as much as possible.
 `json-rfc.py` creates the JSON from the RFC Editor's index. Try `make rfcs.json.gz`.
 
 JavaScript should be formatted according to
-[standard](https://github.com/standard/standard); try `make standard`.
+[standard](https://github.com/standard/standard); try `make lint`.
 


### PR DESCRIPTION
... or, is it better to change target name in Makefile from "lint" to "standard"?